### PR TITLE
docs: refocus org profile on Edictum after captatum/qratum decouple

### DIFF
--- a/assets/captatum-mark.svg
+++ b/assets/captatum-mark.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="96" height="96" role="img" aria-label="Captatum">
-  <g fill="none" stroke="currentColor" stroke-width="9" stroke-linecap="square" stroke-linejoin="miter">
-    <path d="M 16 50 C 36 24 64 24 84 50"></path>
-    <path d="M 16 50 C 36 76 64 76 84 50"></path>
-  </g>
-  <circle cx="50" cy="50" r="9" fill="currentColor"></circle>
-</svg>

--- a/assets/qratum-mark.svg
+++ b/assets/qratum-mark.svg
@@ -1,9 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="96" height="96" role="img" aria-label="Qratum">
-  <g fill="none" stroke="currentColor" stroke-width="9" stroke-linecap="square" stroke-linejoin="miter">
-    <path d="M 36 18 L 30 78"></path>
-    <path d="M 58 18 L 52 78"></path>
-    <path d="M 20 40 L 70 40"></path>
-    <path d="M 18 60 L 68 60"></path>
-  </g>
-  <circle cx="84" cy="72" r="7" fill="currentColor"></circle>
-</svg>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,16 +1,13 @@
 <div align="center">
 
 <img src="../assets/edictum-mark.svg" alt="" width="40">
-<img src="../assets/captatum-mark.svg" alt="" width="40">
-<img src="../assets/qratum-mark.svg" alt="" width="40">
 
 # edictum-ai
 
-A family of tools for AI agents in production — enforcement, fetch, and provenance.
+Runtime governance for AI agents — allow, block, or require approval on tool calls, with a full audit trail, before they execute.
 
 [![PyPI](https://img.shields.io/pypi/v/edictum?label=PyPI&color=blue)](https://pypi.org/project/edictum/)
 [![npm](https://img.shields.io/npm/v/@edictum/core?label=@edictum/core&color=blue)](https://www.npmjs.com/package/@edictum/core)
-[![npm captatum](https://img.shields.io/npm/v/@edictum/captatum?label=@edictum/captatum&color=blue)](https://www.npmjs.com/package/@edictum/captatum)
 [![Go Reference](https://pkg.go.dev/badge/github.com/edictum-ai/edictum-go.svg)](https://pkg.go.dev/github.com/edictum-ai/edictum-go)
 [![Docs](https://img.shields.io/badge/docs-docs.edictum.ai-blue)](https://docs.edictum.ai)
 [![Website](https://img.shields.io/badge/site-edictum.ai-black)](https://edictum.ai)
@@ -20,13 +17,13 @@ A family of tools for AI agents in production — enforcement, fetch, and proven
 
 ---
 
-## Tools
+## Edictum
 
-| Tool | Role | Install |
-| --- | --- | --- |
-| <img src="../assets/edictum-mark.svg" width="14" valign="middle"> [Edictum](https://github.com/edictum-ai/edictum) | Runtime enforcement for agent tool calls — rules and workflow gates at the tool boundary (Python / TypeScript / Go) | `pip install edictum[yaml]` · `pnpm add @edictum/core` · `go get github.com/edictum-ai/edictum-go` |
-| <img src="../assets/captatum-mark.svg" width="14" valign="middle"> [Captatum](https://github.com/edictum-ai/captatum) | Adaptive MCP web-fetch — fetch any URL, render JS when needed, return content plus a provenance receipt | `npx -y @edictum/captatum` |
-| <img src="../assets/qratum-mark.svg" width="14" valign="middle"> [Qratum](https://github.com/edictum-ai/qratum) | Session vault — capture, redact, and prove the provenance of agent runs | see [repo](https://github.com/edictum-ai/qratum) |
+Runtime enforcement for agent tool calls — deterministic rules and workflow gates at the tool boundary, with an audit trail on every decision. Available for Python, TypeScript, and Go.
+
+| Surface | Install |
+| --- | --- |
+| <img src="../assets/edictum-mark.svg" width="14" valign="middle"> [Edictum](https://github.com/edictum-ai/edictum) | `pip install edictum[yaml]` · `pnpm add @edictum/core` · `go get github.com/edictum-ai/edictum-go` |
 
 ## Edictum SDKs
 
@@ -41,16 +38,14 @@ A family of tools for AI agents in production — enforcement, fetch, and proven
 
 | Repo | Role |
 | --- | --- |
-| [captatum](https://github.com/edictum-ai/captatum) | Adaptive MCP web-fetch |
 | [edictum](https://github.com/edictum-ai/edictum) | Python SDK |
 | [edictum-ts](https://github.com/edictum-ai/edictum-ts) | TypeScript SDK monorepo |
 | [edictum-go](https://github.com/edictum-ai/edictum-go) | Go SDK and Gate CLI |
 | [edictum-openclaw](https://github.com/edictum-ai/edictum-openclaw) | OpenClaw plugin and adapter |
 | [edictum-schemas](https://github.com/edictum-ai/edictum-schemas) | Shared schemas and conformance fixtures |
 | [edictum-demo](https://github.com/edictum-ai/edictum-demo) | Demo scenarios and example policies |
-| [qratum](https://github.com/edictum-ai/qratum) | Session provenance vault |
 
-Private server, website, and docs repos exist in the org, but they are not listed here because this profile is public.
+Private platform, website, and docs repos also exist in the org. They are not listed here because this profile is public.
 
 ## Research
 


### PR DESCRIPTION
captatum and qratum have moved out of the org to `github.com/acartag7`. This updates the org profile to present the Edictum enforcement line and its SDKs only.

- Drop captatum + qratum rows from **Tools** and **Repositories**
- Remove the `@edictum/captatum` npm badge and the captatum/qratum header marks
- Delete the now-orphaned `assets/captatum-mark.svg` and `assets/qratum-mark.svg`
- Retitle the intro from "a family of tools — enforcement, fetch, provenance" to the enforcement-focused tagline